### PR TITLE
Fix the source currencies filter for Payments#find_path

### DIFF
--- a/lib/ripple-rest/helpers.rb
+++ b/lib/ripple-rest/helpers.rb
@@ -126,7 +126,7 @@ module RippleRest
       
       if source_currencies
         cur = source_currencies.join(",")
-        uri += "?#{cur}"
+        uri += "?source_currencies=#{cur}"
       end
       
       RippleRest.get(uri)["payments"].map(&Payment.method(:new)).map do |i|


### PR DESCRIPTION
The source_currencies param needs to be named.
https://dev.ripple.com/?p=ripple-rest#preparing-a-payment
