### PR TITLE
Enure that json is submitted when posting to ripple

### DIFF
--- a/lib/ripple-rest.rb
+++ b/lib/ripple-rest.rb
@@ -59,7 +59,7 @@ class << RippleRest
   
   # @api private
   def post uri, args = {}
-    wrap_error { RestClient.post "#{@endpoint}/#{uri}", args, :content_type => :json }
+    wrap_error { RestClient.post "#{@endpoint}/#{uri}", args.to_json, :content_type => :json }
   end
   
   # @api private


### PR DESCRIPTION
I've encountered the problem with posting the hash when testing some payments.
The fix is to convert the arguments to json before sending.

Hash#to_json comes from rest-client
